### PR TITLE
Adiciona o usuário anônimo no kibana e ES, aumenta a quantidade de memória para o ES.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - 9300:9300
     environment:
       node.name: elasticsearch
-      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      ES_JAVA_OPTS: -Xms4g -Xmx4g
       # Bootstrap password.
       # Used to initialize the keystore during the initial startup of
       # Elasticsearch. Ignored on subsequent runs.

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -10,3 +10,9 @@ network.host: 0.0.0.0
 #
 xpack.license.self_generated.type: trial
 xpack.security.enabled: true
+
+xpack.security.authc:
+  anonymous:
+    username: anonymous_user 
+    roles: anonymous
+    authz_exception: true 

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -14,6 +14,16 @@ monitoring.ui.container.logstash.enabled: true
 elasticsearch.username: kibana_system
 elasticsearch.password: ${KIBANA_SYSTEM_PASSWORD}
 
+
+xpack.security.authc.providers:
+  basic.basic1:
+    order: 0
+  anonymous.anonymous1:
+    order: 1
+    credentials:
+      username: "anonymous_service_account"
+      password: "anonymous_service_account_password"
+
 ## Encryption keys (optional but highly recommended)
 ##
 ## Generate with either


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona as configurações de usuário anônimo para o projeto.

#### Onde a revisão poderia começar?

Pelos commits 

#### Como este poderia ser testado manualmente?

Para teste sugiro baixar o projeto realizar as configurações indicadas no issue #2


#### Algum cenário de contexto que queira dar?

Essa atividade se faz necessária para que possamos abrir os dashboards sem a necessidade de usuário e senha. 

Além das configurações de anônimo foi realizado uma configuração a aumento de memória para o java do ES.

### Screenshots
N/A

#### Quais são tickets relevantes?
#2

### Referências

https://discuss.elastic.co/t/turn-on-anonymous-access/285955